### PR TITLE
Back - Ajustar API - Permisos

### DIFF
--- a/API/src/guards/index.js
+++ b/API/src/guards/index.js
@@ -6,6 +6,7 @@ const isCoordinator = require("./isCoordinator");
 const isCustomer = require("./isCustomer");
 const isShopping = require("./isShopping");
 const isTechnical = require("./isTechnical");
+const isNotCustomer = require("./isNotCustomer");
 
 module.exports = {
   isAdmin,
@@ -14,6 +15,7 @@ module.exports = {
   isCustomer,
   isShopping,
   isTechnical,
+  isNotCustomer,
   verifyToken,
   validateGrants,
 };

--- a/API/src/guards/isNotCustomer.js
+++ b/API/src/guards/isNotCustomer.js
@@ -1,0 +1,36 @@
+const express = require("express");
+const router = express.Router();
+
+function senResponse(res, type, data, status = 200) {
+  const result = {
+    type: type,
+    data: data,
+  };
+  return res.status(status).send(result);
+}
+
+router.use((req, res, next) => {
+  const decoded = req.decoded;
+  if (decoded) {
+    if (
+      decoded.role.roleName == "Administrador" ||
+      decoded.role.roleName == "Asesor comercial" ||
+      decoded.role.roleName == "Coordinador técnico" ||
+      decoded.role.roleName == "Técnico" ||
+      decoded.role.roleName == "Compras"
+    ) {
+      next();
+    } else {
+      return senResponse(
+        res,
+        "error",
+        { mensaje: `Permiso denegado al rol ${decoded.role.roleName}` },
+        401
+      );
+    }
+  } else {
+    return senResponse(res, "error", { mensaje: "Rol no determinado" }, 401);
+  }
+});
+
+module.exports = router;

--- a/API/src/routes/machine.js
+++ b/API/src/routes/machine.js
@@ -3,16 +3,16 @@ const ctrl = require("../controllers/machine");
 const guards = require("../guards/index");
 const router = express.Router();
 
-router.post("/", [guards.verifyToken, guards.isShopping], ctrl.create);
-router.put("/:id", [guards.verifyToken, guards.isShopping], ctrl.updateById);
+router.post("/", [guards.verifyToken, guards.isNotCustomer], ctrl.create);
+router.put("/:id", [guards.verifyToken, guards.isNotCustomer], ctrl.updateById);
 router.put(
   "/review/:id",
-  [guards.verifyToken, guards.isTechnical],
+  [guards.verifyToken, guards.isNotCustomer],
   ctrl.updateByIdReview
 );
 router.put(
   "/fail/:id",
-  [guards.verifyToken, guards.isTechnical],
+  [guards.verifyToken, guards.isNotCustomer],
   ctrl.updateByIdFail
 );
 router.get("/", guards.verifyToken, ctrl.getAll);

--- a/API/src/routes/person.js
+++ b/API/src/routes/person.js
@@ -3,12 +3,12 @@ const router = express.Router();
 const ctrl = require("../controllers/person");
 const guards = require("../guards/index");
 
-router.post("/", guards.verifyToken, guards.validateGrants, ctrl.create);
-router.put("/:id", guards.verifyToken, guards.validateGrants, ctrl.updateById);
+router.post("/", guards.verifyToken, guards.isAdmin, ctrl.create);
+router.put("/:id", guards.verifyToken, guards.isAdmin, ctrl.updateById);
 router.put(
   "/machine/:id",
   guards.verifyToken,
-  guards.isAdvisor,
+  guards.isAdmin,
   ctrl.addMachineByPersonId
 );
 router.get("/", guards.verifyToken, ctrl.getAll);


### PR DESCRIPTION
Se ajustan los permisos para que solo los usuarios administradores creen los terceros y las demás actividades puedan ser realizadas por cualquier usuario excepto el rol "Cliente".